### PR TITLE
async callback support

### DIFF
--- a/asgi_gssapi.py
+++ b/asgi_gssapi.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import socket
+import inspect
 from typing import Optional, Callable, Union, List
 
 import gssapi
@@ -127,7 +128,10 @@ class SPNEGOAuthMiddleware:
         if scope["type"] != "http":
             return await self._app(scope, receive, send)
 
-        auth_required = self._auth_required_callback(scope)
+        if inspect.iscoroutinefunction(self._auth_required_callback):
+            auth_required = await self._auth_required_callback(scope)
+        else:
+            auth_required = self._auth_required_callback(scope)
         auth_attempted = False
         auth_complete = False
         www_auth_header = []

--- a/test_asgi_gssapi.py
+++ b/test_asgi_gssapi.py
@@ -107,7 +107,8 @@ async def test_authentication_valid_but_not_required(decode, step):
     """
     decode.return_value = "CTOKEN"
     step.return_value = b"STOKEN"
-    false = lambda x: False
+    async def false(scope):
+        return False
     async with TestClient(
         SPNEGOAuthMiddleware(
             index,


### PR DESCRIPTION
Hi,
currently auth_required_callback values don't get awaited. This patch adds support for async callbacks and still retains compatibility to sync functions.
I just modified one of the test cases as completely copying one case seemed a bit like overkill to me.
Hopefully this can be merged!
Cheers,
Stephan